### PR TITLE
Output directory tweaks

### DIFF
--- a/config/ycsb_local.yml
+++ b/config/ycsb_local.yml
@@ -7,10 +7,16 @@ client:
   number: 1
 
 threads:
-  load: 40
-  run: 256
+  load: 2
+  run: 8
 
 data:
   fieldcount: 10
   fieldlength: 10
-  records: 100_000
+  records: 50
+  operations: 10
+  load: true
+  # Read-mostly workload: workload B: 95% read to 5% update ratio
+  # Read/write combination: workload A: 50% read to 50% update ratio
+  # Read-modify-write: workload F: 50% read to 50% read-modify-write ratio
+  workloads: ["workloadb", "workloada", "workloadf"]

--- a/run.py
+++ b/run.py
@@ -53,8 +53,11 @@ def main():
             print(exc)
             exit(-1)
 
-    mkdir_p(args.reportpath)
-    config['reportpath'] = args.reportpath
+    executionid = time.strftime("%d%m%Y_%H%M%S")
+
+    report_dir = os.path.join(args.reportpath, executionid)
+    mkdir_p(report_dir)
+    config['reportpath'] = report_dir
     if args.ycsb and (args.ycsb_path or args.ycsb_tar_path or args.ycsb_remote_tar_path):
         config['ycsb_repo'] = {'ycsb_path': args.ycsb_path, 'ycsb_tar_path': args.ycsb_tar_path, 'ycsb_remote_tar_path': args.ycsb_remote_tar_path}
     credentials = None
@@ -65,7 +68,6 @@ def main():
             print(exc)
             exit(-1)
 
-    executionid = time.strftime("%d%m%Y_%H%M%S")
     ycsb_benchmark = ycsb.YCSB(executionid, config, credentials)
     ycsb_benchmark.run()
 

--- a/ycsb.py
+++ b/ycsb.py
@@ -79,8 +79,8 @@ class YCSB:
                       "-p fieldcount={fieldcount} " \
                       "-p fieldlength={fieldlength} " \
                       "-p hdrhistogram.fileoutput=true " \
-                      "-p hdrhistogram.output.path=/tmp/hist_{execution_id}.log " \
-                      "2>&1 | tee /tmp/graknbench_{execution_id} \"".format(
+                      "-p hdrhistogram.output.path=/tmp/{execution_id}/hist.log " \
+                      "2>&1 | tee /tmp/{execution_id}/graknbench.log \"".format(
                 execution_id=self.execution_id, cluster_uri=cluster_uri, recordcount=data_["records"],
                 threads=self.config["threads"]["run"], fieldcount=data_["fieldcount"], workload=workload,
                 fieldlength=data_["fieldlength"], operationcount=data_["operations"])
@@ -109,8 +109,8 @@ class YCSB:
                       "-p fieldcount={fieldcount} " \
                       "-p fieldlength={fieldlength} " \
                       "-p hdrhistogram.fileoutput=true " \
-                      "-p hdrhistogram.output.path=/tmp/hist_{execution_id}.log " \
-                      "2>&1 | tee /tmp/graknbench_{execution_id}.log \"".format(
+                      "-p hdrhistogram.output.path=/tmp/{execution_id}/hist.log " \
+                      "2>&1 | tee /tmp/{execution_id}/graknbench.log \"".format(
                 execution_id=self.execution_id, cluster_uri=cluster_uri, recordcount=data_["records"],
                 threads=self.config["threads"]["load"], fieldcount=data_["fieldcount"], workload=workload,
                 fieldlength=data_["fieldlength"], operationcount=data_["operations"])
@@ -123,7 +123,7 @@ class YCSB:
     def execute_and_monitor_command(self, client, client_uri, command, results):
         logger.debug("Command from %s: %s", client_uri, command)
         stdin, stdout, stderr = client.exec_command(command)
-        with open(os.path.join(self.config['reportpath'], self.execution_id + "_benchmark.log"), 'a') as local_log_file:
+        with open(os.path.join(self.config['reportpath'], "benchmark.log"), 'a') as local_log_file:
             for line in iter(lambda: stdout.readline(2048), ""):
                 if "est completion in" in line or "Return=" in line:
                     logger.info(client_uri + ": " + line.replace("\n", ""))
@@ -142,7 +142,7 @@ class YCSB:
         with Pool(processes=len(client_uris)) as pool:
             results = pool.starmap(f, [(uri, cluster_uri, workload) for uri in client_uris])
         js = json.dumps(results)
-        with open(os.path.join(self.config['reportpath'], self.execution_id + "_{}_{}.json".format(name, workload)),
+        with open(os.path.join(self.config['reportpath'], "{}_{}.json".format(name, workload)),
                   'w') as fp:
             fp.write(js)
 


### PR DESCRIPTION
1. Reports for each execution are now stored in a single directory, `reports/{executionid}`
2. Tmp files for an execution are now also under a single directory, `/tmp/{executionid}`